### PR TITLE
Run markdown test in parallel.

### DIFF
--- a/pkg/gits/commits_integration_test.go
+++ b/pkg/gits/commits_integration_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestChangelogMarkdown(t *testing.T) {
+	t.Parallel()
 	releaseSpec := &v1.ReleaseSpec{
 		Commits: []v1.CommitSummary{
 			{


### PR DESCRIPTION
This is an intentional bug that should be caught by [CodeLingo](https://www.codelingo.io/).